### PR TITLE
Small change to `README` / setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ conda activate gp
 
 The module works with pip. To install, use:
 ```shell
-$ pip install .
+$ pip install gp
 ```
 
 Alternatively, you can install manually using CMake. You can compile and install everything with:


### PR DESCRIPTION
running the original `pip install .` threw the following error due to directory issues:

```bash
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

The following change bypassed the wd issue and worked: 

```bash
pip install gp
```

Thus, I am suggesting this change.